### PR TITLE
Details Paparazzi snapshots, parallel PR pipeline, and AI quality agents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,5 +38,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           min-coverage-overall: 60
           min-coverage-changed-files: 70
-          title: Unit Test Coverage
+          title: Unit Test Coverage (incl. Paparazzi)
           update-comment: true

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 jobs:
-  static-analysis:
+  install:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -22,17 +22,25 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
       - name: Set up Gradle caching
         uses: gradle/actions/setup-gradle@v4
 
       - name: Grant execute permissions to Gradle wrapper
         run: chmod +x ./gradlew
 
-      - name: Run Detekt static analysis
-        run: ./gradlew detekt
+      - name: Warm Gradle dependency cache
+        run: ./gradlew dependencies --no-daemon
 
-  unit-tests:
+  gradle-checks:
+    needs: install
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        task: [detekt, ktlintCheck, testDebugUnitTest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -43,16 +51,57 @@ jobs:
           distribution: temurin
           java-version: 17
 
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
       - name: Set up Gradle caching
         uses: gradle/actions/setup-gradle@v4
 
       - name: Grant execute permissions to Gradle wrapper
         run: chmod +x ./gradlew
 
-      - name: Run unit tests
-        run: ./gradlew testDebugUnitTest
+      - name: Run ${{ matrix.task }}
+        run: ./gradlew ${{ matrix.task }}
+
+  coverage:
+    needs: install
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle caching
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permissions to Gradle wrapper
+        run: chmod +x ./gradlew
+
+      - name: Run unit tests and generate coverage report
+        run: ./gradlew testDebugUnitTest jacocoFullReport
+
+      - name: Post coverage to PR
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          paths: build/reports/jacoco/jacoco.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 60
+          min-coverage-changed-files: 70
+          title: Unit Test Coverage (incl. Paparazzi)
+          update-comment: true
 
   ai-review:
+    needs: install
     if: ${{ secrets.OPENAI_API_KEY != '' }}
     runs-on: ubuntu-latest
     permissions:
@@ -76,6 +125,7 @@ jobs:
         run: python scripts/quality_agent/pr_reviewer.py
 
   ai-ui-test-gen:
+    needs: install
     if: ${{ secrets.OPENAI_API_KEY != '' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -6,8 +6,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
-  build-and-test:
+  static-analysis:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -28,5 +31,46 @@ jobs:
       - name: Run Detekt static analysis
         run: ./gradlew detekt
 
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle caching
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permissions to Gradle wrapper
+        run: chmod +x ./gradlew
+
       - name: Run unit tests
         run: ./gradlew testDebugUnitTest
+
+  ai-review:
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r scripts/quality_agent/requirements.txt
+
+      - name: Run AI PR review
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/quality_agent/pr_reviewer.py

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -1,0 +1,32 @@
+name: PR Pipeline
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Gradle caching
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permissions to Gradle wrapper
+        run: chmod +x ./gradlew
+
+      - name: Run Detekt static analysis
+        run: ./gradlew detekt
+
+      - name: Run unit tests
+        run: ./gradlew testDebugUnitTest

--- a/.github/workflows/pr_pipeline.yml
+++ b/.github/workflows/pr_pipeline.yml
@@ -74,3 +74,26 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/quality_agent/pr_reviewer.py
+
+  ai-ui-test-gen:
+    if: ${{ secrets.OPENAI_API_KEY != '' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -r scripts/quality_agent/requirements.txt
+
+      - name: Run Maestro UI test generator
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python scripts/quality_agent/maestro_generator.py

--- a/README.md
+++ b/README.md
@@ -35,11 +35,19 @@ cd droidpokedex
 ./gradlew :app:assembleDebug
 ```
 
-Run unit tests (includes Paparazzi snapshot tests under `app/src/test`, which compare against checked-in golden images):
+Run unit tests (includes **Paparazzi** snapshot tests under `app/src/test`, which compare against checked-in golden images):
 
 ```sh
 ./gradlew test
 ```
+
+Generate a unified **JaCoCo** report (domain/data ViewModel tests **and** Compose UI exercised by Paparazzi in `:app`):
+
+```sh
+./gradlew jacocoFullReport
+```
+
+Open `build/reports/jacoco/html/index.html` for the HTML report. CI runs the same report on every PR and posts coverage from `build/reports/jacoco/jacoco.xml`.
 
 After intentional UI changes, record new Paparazzi baselines:
 
@@ -52,7 +60,7 @@ After intentional UI changes, record new Paparazzi baselines:
 [GitHub Actions](https://docs.github.com/en/actions) runs on every **push** and **pull request** targeting **`main`**. The workflow is defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml): it sets up **Temurin JDK 17**, the **Android SDK** (`android-actions/setup-android`), Gradle caching (`gradle/actions/setup-gradle`), then runs **`assembleDebug`**, **`ktlintCheck`**, **`detekt`**, and **`test`** (Gradle may reorder tasks according to the task graph):
 
 ```sh
-./gradlew assembleDebug ktlintCheck detekt test --stacktrace -Dorg.gradle.java.home="$JAVA_HOME"
+./gradlew assembleDebug ktlintCheck detekt test jacocoFullReport --stacktrace -Dorg.gradle.java.home="$JAVA_HOME"
 ```
 
 The `-Dorg.gradle.java.home=…` flag matches CI’s JDK with the value from `actions/setup-java` and overrides the optional machine-specific `org.gradle.java.home` entry in [`gradle.properties`](gradle.properties) (for example a local Homebrew path). Instrumented tests on an emulator are not part of this workflow; run those locally when needed.
@@ -109,9 +117,11 @@ Reusable Compose primitives and **@Preview**-backed components live under [`app/
 |-------|----------|----------|
 | Domain | JUnit, MockK, coroutines test | [`SearchPokemonUseCaseTest`](home/domain/src/test/java/com/rodriguesalex/domain/SearchPokemonUseCaseTest.kt), [`GetPokeHomeUseCaseTest`](home/domain/src/test/java/com/rodriguesalex/domain/GetPokeHomeUseCaseTest.kt) |
 | Data | JUnit, MockK, coroutines test | [`PokeHomeRepositoryImplTest`](home/data/src/test/java/com/rodriguesalex/data/PokeHomeRepositoryImplTest.kt) |
-| Presentation | JUnit, MockK, `StandardTestDispatcher` | [`DroidHomeViewModelTest`](app/src/test/java/com/rodriguesalex/droidpokedex/home/viewmodel/DroidHomeViewModelTest.kt) |
-| UI snapshots | Paparazzi | [`DroidHomeCellPaparazziTest`](app/src/test/java/com/rodriguesalex/droidpokedex/DroidHomeCellPaparazziTest.kt), [`DroidDetailsPaparazziTest`](app/src/test/java/com/rodriguesalex/droidpokedex/details/DroidDetailsPaparazziTest.kt), [`SimplePaparazziTest`](app/src/test/java/com/rodriguesalex/droidpokedex/SimplePaparazziTest.kt) |
+| Presentation | JUnit, MockK, `StandardTestDispatcher` | [`DroidHomeViewModelTest`](app/src/test/java/com/rodriguesalex/droidpokedex/home/viewmodel/DroidHomeViewModelTest.kt), [`DroidDetailsViewModelTest`](app/src/test/java/com/rodriguesalex/droidpokedex/details/viewmodel/DroidDetailsViewModelTest.kt) |
+| UI (unit / JVM) | Paparazzi — runs in `testDebugUnitTest`, counts toward JaCoCo | [`DroidHomeCellPaparazziTest`](app/src/test/java/com/rodriguesalex/droidpokedex/DroidHomeCellPaparazziTest.kt), [`DroidDetailsPaparazziTest`](app/src/test/java/com/rodriguesalex/droidpokedex/details/DroidDetailsPaparazziTest.kt) |
 | On-device UI | Compose UI test dependencies on `:app` | `androidTest` with `ui-test-junit4` (run on emulator/device) |
+
+Paparazzi is not a separate test suite: it executes with **`./gradlew test`** and feeds the same **`jacocoFullReport`** as ViewModel and domain tests. Screens and design-system code covered by snapshot tests (for example [`DroidDetailsScreenContent`](app/src/main/java/com/rodriguesalex/droidpokedex/details/DroidDetailsScreen.kt)) are included in coverage metrics; `@Preview` composables remain excluded.
 
 ## Code quality
 
@@ -131,7 +141,7 @@ To run the default verification pipeline for all modules (unit tests, Android Li
 ## Limitations and possible extensions
 
 - **No durable offline store**: in-memory cache helps during a single run when the API fails; **persisting** lists or details (Room, DataStore, or similar) would improve true offline use and startup after process death. Coil still caches images for URLs on disk where configured.
-- **CI** on `main` runs **`assembleDebug`**, **`ktlintCheck`**, **`detekt`**, and **`test`** (see [Continuous integration](#continuous-integration)). The full **`./gradlew check`** graph (including Android Lint) is not run in CI unless you add it.
+- **CI** on `main` runs **`assembleDebug`**, **`ktlintCheck`**, **`detekt`**, **`test`** (including Paparazzi), and **`jacocoFullReport`** with PR coverage comments (see [Continuous integration](#continuous-integration)). The full **`./gradlew check`** graph (including Android Lint) is not run in CI unless you add it.
 - **Accessibility**: Compose previews help iteration, but a serious pass would add content descriptions, contrast checks, and TalkBack testing—not claimed here.
 
 ## Tech stack (summary)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,7 +57,8 @@ subprojects {
 
 tasks.register<JacocoReport>("jacocoFullReport") {
     group = "verification"
-    description = "Generate unified JaCoCo coverage report for all modules"
+    description =
+        "Generate unified JaCoCo coverage report (unit tests + Paparazzi snapshot tests in :app)"
 
     val coverageModules = listOf(
         "app",
@@ -67,6 +68,7 @@ tasks.register<JacocoReport>("jacocoFullReport") {
         "home:data",
     )
 
+    // Paparazzi tests run as part of :app:testDebugUnitTest; their execution data is included below.
     dependsOn(coverageModules.map { ":$it:testDebugUnitTest" })
 
     val excludePatterns = listOf(
@@ -82,10 +84,8 @@ tasks.register<JacocoReport>("jacocoFullReport") {
         "**/Hilt_*",
         "**/*Hilt*",
         "**/*_Impl*",
-        "**/designsystem/**",
         "**/navigation/**",
         "**/ui/theme/**",
-        "**/*Screen*",
         "**/*Preview*",
     )
 

--- a/maestro/smoke_test.yaml
+++ b/maestro/smoke_test.yaml
@@ -1,0 +1,7 @@
+appId: com.rodriguesalex.droidpokedex
+---
+- launchApp
+- assertVisible: "Pokemon"
+- tapOn:
+    index: 0
+- pressKey: back

--- a/scripts/quality_agent/maestro_generator.py
+++ b/scripts/quality_agent/maestro_generator.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Generate Maestro UI test YAML from a PR diff via OpenAI and post as a PR comment."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import requests
+from openai import OpenAI
+
+DIFF_CHAR_LIMIT = 12_000
+GITHUB_API = "https://api.github.com"
+MODEL = "gpt-4o"
+COMMENT_HEADER = "🤖 Auto-Generated Maestro UI Test for this PR"
+SYSTEM_PROMPT = "You are an Android Quality Engineer."
+USER_PROMPT_TEMPLATE = (
+    "Analyze this Git Diff. If any new UI elements (like buttons, text fields, or screens) "
+    "were added in this PR, generate a valid Maestro UI test (YAML) to interact with them. "
+    "Only output the YAML.\n\n"
+    "Use appId: com.rodriguesalex.droidpokedex unless the diff indicates otherwise.\n\n"
+    "```diff\n{diff}\n```"
+)
+
+
+def main() -> int:
+    openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    github_token = os.environ.get("GITHUB_TOKEN", "").strip()
+
+    if not openai_key or not github_token:
+        print("API keys not configured. Skipping Maestro UI test generation.")
+        return 0
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path or not Path(event_path).is_file():
+        print("GITHUB_EVENT_PATH not set or missing. Skipping Maestro UI test generation.")
+        return 0
+
+    with open(event_path, encoding="utf-8") as f:
+        event = json.load(f)
+
+    pull_request = event.get("pull_request")
+    if not pull_request:
+        print("Not a pull_request event. Skipping Maestro UI test generation.")
+        return 0
+
+    pr_number = pull_request["number"]
+    repo = event.get("repository", {})
+    owner = repo.get("owner", {}).get("login") or event.get("organization", {}).get("login")
+    repo_name = repo.get("name")
+
+    if not owner or not repo_name:
+        print("Could not determine repository from event payload. Skipping Maestro UI test generation.")
+        return 0
+
+    diff = fetch_pr_diff(owner, repo_name, pr_number, github_token)
+    if not diff.strip():
+        print("PR diff is empty. Skipping Maestro UI test generation.")
+        return 0
+
+    yaml_content = generate_maestro_yaml(diff, openai_key)
+    if not yaml_content.strip():
+        print("Model returned no YAML. Skipping PR comment.")
+        return 0
+
+    comment_body = format_pr_comment(yaml_content)
+    post_pr_comment(owner, repo_name, pr_number, github_token, comment_body)
+    print("Maestro UI test comment posted successfully.")
+    return 0
+
+
+def fetch_pr_diff(owner: str, repo: str, pr_number: int, token: str) -> str:
+    url = f"{GITHUB_API}/repos/{owner}/{repo}/pulls/{pr_number}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github.v3.diff",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    response = requests.get(url, headers=headers, timeout=120)
+    response.raise_for_status()
+    diff = response.text
+    if len(diff) > DIFF_CHAR_LIMIT:
+        diff = diff[:DIFF_CHAR_LIMIT] + "\n\n... (diff truncated for model context)"
+    return diff
+
+
+def generate_maestro_yaml(diff: str, openai_key: str) -> str:
+    client = OpenAI(api_key=openai_key)
+    completion = client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": USER_PROMPT_TEMPLATE.format(diff=diff)},
+        ],
+        max_tokens=2000,
+    )
+    raw = (completion.choices[0].message.content or "").strip()
+    return strip_yaml_fences(raw)
+
+
+def strip_yaml_fences(text: str) -> str:
+    """Remove markdown code fences if the model wrapped YAML in ``` blocks."""
+    match = re.search(r"```(?:yaml|yml)?\s*\n(.*?)```", text, re.DOTALL | re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
+
+
+def format_pr_comment(yaml_content: str) -> str:
+    return f"## {COMMENT_HEADER}\n\n```yaml\n{yaml_content}\n```"
+
+
+def post_pr_comment(owner: str, repo: str, pr_number: int, token: str, body: str) -> None:
+    url = f"{GITHUB_API}/repos/{owner}/{repo}/issues/{pr_number}/comments"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    response = requests.post(url, headers=headers, json={"body": body}, timeout=60)
+    response.raise_for_status()
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except requests.HTTPError as e:
+        print(f"GitHub API error: {e}", file=sys.stderr)
+        if e.response is not None:
+            print(e.response.text, file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Maestro UI test generation failed: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/quality_agent/pr_reviewer.py
+++ b/scripts/quality_agent/pr_reviewer.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""AI-powered PR reviewer: fetches diff, summarizes via OpenAI, posts a PR comment."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import requests
+from openai import OpenAI
+
+DIFF_CHAR_LIMIT = 12_000
+GITHUB_API = "https://api.github.com"
+MODEL = "gpt-4o-mini"
+
+
+def main() -> int:
+    openai_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    github_token = os.environ.get("GITHUB_TOKEN", "").strip()
+
+    if not openai_key or not github_token:
+        print("API keys not configured. Skipping AI review.")
+        return 0
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if not event_path or not Path(event_path).is_file():
+        print("GITHUB_EVENT_PATH not set or missing. Skipping AI review.")
+        return 0
+
+    with open(event_path, encoding="utf-8") as f:
+        event = json.load(f)
+
+    pull_request = event.get("pull_request")
+    if not pull_request:
+        print("Not a pull_request event. Skipping AI review.")
+        return 0
+
+    pr_number = pull_request["number"]
+    repo = event.get("repository", {})
+    owner = repo.get("owner", {}).get("login") or event.get("organization", {}).get("login")
+    repo_name = repo.get("name")
+
+    if not owner or not repo_name:
+        print("Could not determine repository from event payload. Skipping AI review.")
+        return 0
+
+    diff = fetch_pr_diff(owner, repo_name, pr_number, github_token)
+    if not diff.strip():
+        print("PR diff is empty. Skipping AI review.")
+        return 0
+
+    review_body = generate_review(diff, openai_key)
+    post_pr_comment(owner, repo_name, pr_number, github_token, review_body)
+    print("AI review posted successfully.")
+    return 0
+
+
+def fetch_pr_diff(owner: str, repo: str, pr_number: int, token: str) -> str:
+    url = f"{GITHUB_API}/repos/{owner}/{repo}/pulls/{pr_number}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github.v3.diff",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    response = requests.get(url, headers=headers, timeout=120)
+    response.raise_for_status()
+    diff = response.text
+    if len(diff) > DIFF_CHAR_LIMIT:
+        diff = diff[:DIFF_CHAR_LIMIT] + "\n\n... (diff truncated for model context)"
+    return diff
+
+
+def generate_review(diff: str, openai_key: str) -> str:
+    client = OpenAI(api_key=openai_key)
+    prompt = (
+        "You are reviewing a pull request for an Android Kotlin project (Jetpack Compose, "
+        "Hilt, multi-module Clean Architecture).\n\n"
+        "Analyze the following git diff and provide:\n"
+        "1. **Architectural impact** — how the changes affect module boundaries, layers, and design.\n"
+        "2. **Potential risks** — bugs, regressions, missing tests, security, or performance concerns.\n\n"
+        "Be concise and actionable. Use markdown.\n\n"
+        f"```diff\n{diff}\n```"
+    )
+    completion = client.chat.completions.create(
+        model=MODEL,
+        messages=[
+            {
+                "role": "system",
+                "content": "You are a senior Android engineer performing code review.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+        max_tokens=1500,
+    )
+    content = completion.choices[0].message.content or ""
+    return "## AI PR Review\n\n" + content.strip()
+
+
+def post_pr_comment(owner: str, repo: str, pr_number: int, token: str, body: str) -> None:
+    url = f"{GITHUB_API}/repos/{owner}/{repo}/issues/{pr_number}/comments"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    response = requests.post(url, headers=headers, json={"body": body}, timeout=60)
+    response.raise_for_status()
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except requests.HTTPError as e:
+        print(f"GitHub API error: {e}", file=sys.stderr)
+        if e.response is not None:
+            print(e.response.text, file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"AI review failed: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/scripts/quality_agent/requirements.txt
+++ b/scripts/quality_agent/requirements.txt
@@ -1,0 +1,2 @@
+requests
+openai


### PR DESCRIPTION
## Summary

Adds snapshot coverage for the details screen, includes Paparazzi-tested UI in JaCoCo reporting, and introduces a parallel PR pipeline with optional AI review and Maestro test generation.

## Changes

### Details UI & Paparazzi
- Extract `DroidDetailsScreenContent` from `DroidDetailsScreen` for testable, ViewModel-free UI
- Add `DroidDetailsPaparazziTest` (loading, success, offline banner, network error)
- Add `DetailsPaparazziFixtures` and golden images under `app/src/test/snapshots/`
- Fix `DetailsScreenPreview` to use static fixture data instead of `hiltViewModel()`

### Coverage
- Include screens and design-system code in `jacocoFullReport` (Paparazzi runs in `testDebugUnitTest`)
- Document `jacocoFullReport` and Paparazzi in README; align CI docs with `jacocoFullReport`

### PR pipeline (`.github/workflows/pr_pipeline.yml`)
Four parallel jobs on PRs to `main`:
| Job | Purpose |
|-----|---------|
| `static-analysis` | `./gradlew detekt` |
| `unit-tests` | `./gradlew testDebugUnitTest` (includes Paparazzi verify) |
| `ai-review` | OpenAI architectural review comment (skipped if `OPENAI_API_KEY` unset) |
| `ai-ui-test-gen` | OpenAI-generated Maestro YAML posted on PR (same secret guard) |

### Quality agents (`scripts/quality_agent/`)
- `pr_reviewer.py` — diff → `gpt-4o-mini` → PR comment
- `maestro_generator.py` — diff → `gpt-4o` → Maestro YAML PR comment
- `requirements.txt` — `requests`, `openai`

### Maestro
- Base smoke flow: `maestro/smoke_test.yaml` (`launchApp`, list assert, tap, back)

## Setup (optional AI jobs)

Add repository secret **`OPENAI_API_KEY`** to enable `ai-review` and `ai-ui-test-gen`. Without it, those jobs are skipped and the script exits gracefully.

## Test plan

- [ ] `./gradlew :app:verifyPaparazziDebug`
- [ ] `./gradlew testDebugUnitTest`
- [ ] `./gradlew detekt`
- [ ] `./gradlew jacocoFullReport` — confirm details/design-system coverage in HTML report
- [ ] (Optional) `maestro test maestro/smoke_test.yaml` on emulator/device
- [ ] Open a test PR and confirm parallel jobs; with `OPENAI_API_KEY`, verify AI review + Maestro comments